### PR TITLE
Make Jelling work by breaking security

### DIFF
--- a/Jelling/Program.cs
+++ b/Jelling/Program.cs
@@ -36,7 +36,7 @@ namespace Jelling
 
         private static GattLocalCharacteristicParameters CHR_PARAMS = new GattLocalCharacteristicParameters
         {
-            WriteProtectionLevel = GattProtectionLevel.EncryptionAndAuthenticationRequired,
+            WriteProtectionLevel = GattProtectionLevel.Plain,
             CharacteristicProperties = GattCharacteristicProperties.Write
                                      | GattCharacteristicProperties.ReliableWrites
                                      | GattCharacteristicProperties.ExtendedProperties,


### PR DESCRIPTION
DO NOT actually merge this patch. This patch exists only to demonstrate how
to make Jelling work while also making it completely insecure.

If EncryptionAndAuthenticationRequired is enabled, Windows does prompt to
pair the device. Once this process concludes, however, no token codes are
ever received.  CharacteristicWriteRequested() is never called. On the
other hand, if we enable Plain mode everything works correctly but we have
no security. Is this a bug with the Windows GATT implementation?